### PR TITLE
Add blood pressure to demo scenarios

### DIFF
--- a/patient/biometric/demo_scenarios/critical.json
+++ b/patient/biometric/demo_scenarios/critical.json
@@ -48,8 +48,8 @@
   {
     "type": "blood_pressure",
     "offset_ms": 1900,
-    "systolic": 180,
-    "diastolic": 110
+    "systolic": 156,
+    "diastolic": 108
   },
   {
     "type": "heart_beat",

--- a/patient/biometric/demo_scenarios/critical.json
+++ b/patient/biometric/demo_scenarios/critical.json
@@ -46,6 +46,12 @@
     "interval_ms": 1861
   },
   {
+    "type": "blood_pressure",
+    "offset_ms": 1900,
+    "systolic": 180,
+    "diastolic": 110
+  },
+  {
     "type": "heart_beat",
     "offset_ms": 1941,
     "value": 85,

--- a/patient/biometric/demo_scenarios/irregular.json
+++ b/patient/biometric/demo_scenarios/irregular.json
@@ -41,6 +41,12 @@
     "pulse_strength": 0.82
   },
   {
+    "type": "blood_pressure",
+    "offset_ms": 1900,
+    "systolic": 130,
+    "diastolic": 85
+  },
+  {
     "type": "heart_beat",
     "offset_ms": 2355,
     "value": 78,

--- a/patient/biometric/demo_scenarios/normal.json
+++ b/patient/biometric/demo_scenarios/normal.json
@@ -34,6 +34,12 @@
     "pulse_strength": 0.994
   },
   {
+    "type": "blood_pressure",
+    "offset_ms": 1900,
+    "systolic": 116,
+    "diastolic": 75
+  },
+  {
     "type": "heart_beat",
     "offset_ms": 1929,
     "value": 64,

--- a/patient/biometric_scenario_server.py
+++ b/patient/biometric_scenario_server.py
@@ -225,6 +225,21 @@ class BiometricScenarioServer:
                     "ecg_rhythm": event.get("value")
                 }
                 
+            elif event_type == "blood_pressure":
+                # Blood pressure events
+                event_data = {
+                    "timestamp": int(current_time),
+                    "scenario": scenario,
+                    "event_type": "vital_signs",
+                    "event_number": event_count,
+                    "interval_ms": wait_time,
+                    "elapsed_ms": int(current_time - scenario_start_time),
+                    "blood_pressure": {
+                        "systolic": event.get("systolic"),
+                        "diastolic": event.get("diastolic")
+                    }
+                }
+                
             else:
                 # Unknown event type - skip or log
                 logger.info(f"Unknown event type: {event_type} - skipping")

--- a/patient/biometric_types.py
+++ b/patient/biometric_types.py
@@ -119,6 +119,8 @@ class DemoScenarioEvent(BaseModel):
     value: Optional[Union[int, float, str]] = Field(default=None, description="Event value")
     interval_ms: Optional[int] = Field(default=None, description="Interval for discrete events")
     pulse_strength: Optional[float] = Field(default=None, description="Pulse strength for heartbeats")
+    systolic: Optional[int] = Field(default=None, description="Systolic blood pressure")
+    diastolic: Optional[int] = Field(default=None, description="Diastolic blood pressure")
 
 class DemoScenarioFile(BaseModel):
     """Structure for demo scenario JSON files."""
@@ -158,6 +160,13 @@ def convert_demo_event_to_biometric_event(demo_event: DemoScenarioEvent, timesta
             event_type="ecg_rhythm",
             timestamp=timestamp,
             ecg_rhythm=demo_event.value or "NSR"
+        )
+    elif event_type == "blood_pressure":
+        return BloodPressureEvent(
+            event_type="blood_pressure",
+            timestamp=timestamp,
+            systolic=demo_event.systolic or 120,
+            diastolic=demo_event.diastolic or 80
         )
     else:
         print(f"Warning: Unknown demo event type: {event_type}")

--- a/patient/monitor.py
+++ b/patient/monitor.py
@@ -442,6 +442,13 @@ class HeartbeatClient:
                                             'ecg_rhythm': event.get('ecg_rhythm')
                                         }
                                         record_biometric_event('ecg_rhythm', event_timestamp, medical_data)
+                                        
+                                    elif 'blood_pressure' in event:
+                                        medical_data = {
+                                            'systolic': event.get('blood_pressure', {}).get('systolic'),
+                                            'diastolic': event.get('blood_pressure', {}).get('diastolic')
+                                        }
+                                        record_biometric_event('blood_pressure', event_timestamp, medical_data)
                                 
                             elif event_type == 'scenario_stopped':
                                 # Update Streamlit session state to reflect that simulation has stopped


### PR DESCRIPTION
This merge will add one more biometric, sent only once in the three scenarios at 1900ms. This is because blood pressure is rarely measured more frequently than once every five minutes as best I can tell. We can add more blood-pressure readings if we want to later.